### PR TITLE
Allow forcing the most common type of indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,15 @@ For the excellent [Atom](https://atom.io/) editor, install the [linter-mixed-ind
 ## Vim
 
 For vim, install mixedindentlint globally on your system as described above, then install the [Syntastic](https://github.com/scrooloose/syntastic/) plugin. Synatastic is filetype-specific, so mixedindentlint will only run on JavaScript, CSS, and SCSS files currently. You may need to configure Syntastic to activate the plugin.
+
+# Options
+
+Rather than scanning each file for the most common type of indentation and then reporting lines which differ (the default behavior), it is possible to specify the style of indentation which the file should have.
+
+On the command-line, this is done with the `--spaces` or `--tabs` options. So the following command will return the line numbers of each line in myFile.js that was NOT indented with tabs:
+
+`mixedindentlint --tabs myFile.js`
+
+Using the node module this is done by passing the `indent` option to `lint()`. Therefore, the following line will return the line numbers of each line in `input` that was NOT indented with spaces:
+
+`lint( input, { indent: 'spaces' } );`

--- a/bin/mixedindentlint.js
+++ b/bin/mixedindentlint.js
@@ -4,7 +4,18 @@ var fs = require( 'fs' );
 var parseArgs = require( 'minimist' );
 var IndentChecker = require( '../lib/indent-checker' );
 
-var argv = parseArgs( process.argv.slice( 2 ) );
+var argv = parseArgs( process.argv.slice( 2 ), {
+	boolean: [
+		'version',
+		'spaces',
+		'tabs'
+	],
+	default: {
+		version: null,
+		spaces: null,
+		tabs: null
+	}
+} );
 var files = argv._;
 
 if ( argv.version ) {
@@ -18,6 +29,8 @@ if ( files.length < 1 ) {
 	console.log( 'Usage: mixedindentlint [options] <file1> [<file2>...]' );
 	console.log( 'Options:' );
 	console.log( '  --version\t\tPrint the current version.' );
+	console.log( '  --spaces\t\tAssume all files should use spaces rather than the most common indentation.' );
+	console.log( '  --tabs\t\tAssume all files should use tabs rather than the most common indentation.' );
 	process.exit( 0 );
 }
 
@@ -28,14 +41,28 @@ var messages = files.reduce( function( warnings, file ) {
 		console.error( 'Error trying to read file "' + file + '":', err.message );
 		process.exit( 1 );
 	}
-	var lines = IndentChecker.getLinesWithLessCommonType( input );
+	var lintOptions = {
+		indent: null
+	};
+	if ( argv.spaces ) {
+		lintOptions.indent = 'spaces';
+	} else if ( argv.tabs ) {
+		lintOptions.indent = 'tabs';
+	}
+	var lines = IndentChecker.lint( input, lintOptions );
 	if ( lines.length > 0 ) warnings[ file ] = lines;
 	return warnings;
 }, {} );
 
+var indentationType = 'the most common type';
+if ( argv.spaces ) {
+	indentationType = 'spaces';
+} else if ( argv.tabs ) {
+	indentationType = 'tabs';
+}
 Object.keys( messages ).map( function( file ) {
 	messages[ file ].map( function( line ) {
-		console.log( 'Line ' + line + ' in "' + file + '" has indentation that differs from the rest of the file.' );
+		console.log( 'Line ' + line + ' in "' + file + '" has indentation that differs from ' + indentationType + '.' );
 	} );
 } );
 

--- a/bin/mixedindentlint.js
+++ b/bin/mixedindentlint.js
@@ -1,14 +1,13 @@
 #!/usr/bin/env node
 
 var fs = require( 'fs' );
+var parseArgs = require( 'minimist' );
 var IndentChecker = require( '../lib/indent-checker' );
 
-var args = process.argv.slice( 2 );
-var files = args.filter( function( arg ) {
-	return arg.substr( 0, 2 ) !== '--';
-} );
+var argv = parseArgs( process.argv.slice( 2 ) );
+var files = argv._;
 
-if ( args[0] === '--version' ) {
+if ( argv.version ) {
 	var version = require( '../package.json' ).version;
 	console.log( 'mixedindentlint version ' + version );
 	process.exit( 0 );
@@ -16,7 +15,9 @@ if ( args[0] === '--version' ) {
 
 if ( files.length < 1 ) {
 	console.log( 'No files to lint' );
-	console.log( 'Usage: mixedindentlint <file1> [<file2>...]' );
+	console.log( 'Usage: mixedindentlint [options] <file1> [<file2>...]' );
+	console.log( 'Options:' );
+	console.log( '  --version\t\tPrint the current version.' );
 	process.exit( 0 );
 }
 

--- a/lib/indent-checker.js
+++ b/lib/indent-checker.js
@@ -42,9 +42,8 @@ var IndentChecker = {
 		}, { type: 'none', count: 0 } ).type;
 	},
 
-	getLinesWithLessCommonType: function( input ) {
+	getLinesWithoutType: function( input, mostCommonType ) {
 		var types = IndentChecker.getLinesByType( input );
-		var mostCommonType = IndentChecker.getMostCommonIndentType( input );
 		if ( mostCommonType === 'none' ) return [];
 		return Object.keys( types ).reduce( function( lines, type ) {
 			if ( type !== mostCommonType && type !== 'none' ) {
@@ -56,7 +55,15 @@ var IndentChecker = {
 		}, [] );
 	},
 
-	lint: function( input ) {
+	getLinesWithLessCommonType: function( input ) {
+		return IndentChecker.getLinesWithoutType( input, IndentChecker.getMostCommonIndentType( input ) );
+	},
+
+	lint: function( input, options ) {
+		options = options || {};
+		if ( options.indent ) {
+			return IndentChecker.getLinesWithoutType( input, options.indent );
+		}
 		return IndentChecker.getLinesWithLessCommonType( input );
 	}
 };

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   },
   "bin": {
     "mixedindentlint": "bin/mixedindentlint.js"
+  },
+  "dependencies": {
+    "minimist": "^1.2.0"
   }
 }

--- a/test/indent-checker-test.js
+++ b/test/indent-checker-test.js
@@ -83,4 +83,16 @@ describe( "IndentChecker", function() {
 			expect( IndentChecker.getLinesWithLessCommonType( input ) ).to.have.same.members( [ 6 ] );
 		} );
 	} );
+
+	describe( ".lint()", function() {
+		it( "returns an array of line numbers with the less-common indentation type from the input", function() {
+			var input = "  foobar1\n  foobar2\n\tfoobar3\n  foobar4\n\tfoobar5";
+			expect( IndentChecker.lint( input ) ).to.have.same.members( [ 3, 5 ] );
+		} );
+
+		it( "returns an array of line numbers without the specified indentation type from the input, if set", function() {
+			var input = "  foobar1\n  foobar2\n\tfoobar3\n  foobar4\n\tfoobar5";
+			expect( IndentChecker.lint( input, { indent: 'tabs' } ) ).to.have.same.members( [ 1, 2, 4 ] );
+		} );
+	} );
 } );


### PR DESCRIPTION
Rather than scanning each file for the most common type of indentation and then reporting lines which differ, this PR makes it possible to specify the style of indentation which the file should have.

On the command-line, this is done with the `--spaces` or `--tabs` options, and in the lib this is done by passing `indent` option to `lint`. Therefore, the following line would return the line numbers of each line in `input` that was not indented with spaces: `lint( input, { indent: 'spaces' } );`
