### PR TITLE
Add support for glob patterns on the CLI script

### DIFF
--- a/bin/mixedindentlint.js
+++ b/bin/mixedindentlint.js
@@ -3,6 +3,7 @@
 var fs = require( 'fs' );
 var path = require( 'path' );
 var parseArgs = require( 'minimist' );
+var globby = require( 'globby' );
 var IndentChecker = require( '../lib/indent-checker' );
 
 function isFileIgnored( file, excludeList ) {
@@ -27,7 +28,7 @@ var argv = parseArgs( process.argv.slice( 2 ), {
 		tabs: null
 	}
 } );
-var files = argv._;
+var files = globby.sync( argv._ );
 
 if ( argv.version ) {
 	var version = require( '../package.json' ).version;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A general-purpose linter for lines that do not match the indentation style of a file",
   "main": "lib/indent-checker.js",
   "scripts": {
-    "test": "node_modules/mocha/bin/mocha"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
@@ -27,6 +27,7 @@
     "mixedindentlint": "bin/mixedindentlint.js"
   },
   "dependencies": {
+    "globby": "^6.1.0",
     "minimist": "^1.2.0"
   }
 }


### PR DESCRIPTION
Switch to use [globby](https://github.com/sindresorhus/globby) patterns instead of a list of plain files. That simplifies code a bit, and it also makes this command easier to use through the build script. Instead of piping the output of a complex `find` command onto `mixedindentlint`, one can now just use something like this instead:
`mixedindentlint **/*.js **/*.jsx !excluded_dir/**`

Note that `globby` makes the `--exclude` argument redundant. I've used that to simplify the code a bit, but I kept it for backwards-compatibility.